### PR TITLE
Port EGL and X11 code to GLFW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-esshader - ShaderToy viewer for X & GLES2
+esshader - offline ShaderToy viewer
 ===========================================
-Simple offline ShaderToy compatible GLSL shader viewer for
-X using OpenGL ES 2.0, inspired by the Suckless Philosophy.
+Simple offline ShaderToy-compatible GLSL shader viewer.
 
 
 Requirements:
 -------------
-In order to build esshader you will need the Xlib, EGL and
+In order to build esshader you will need the GLFW and
 OpenGL ES 2.0 development headers installed on your system.
 The program can also be demanding on GPU hardware, so the
 more powerful GPU you have, the better.

--- a/config.h
+++ b/config.h
@@ -6,14 +6,6 @@
 #include <getopt.h>
 
 
-static const EGLint egl_config[] = {
-    EGL_RED_SIZE, 8,
-    EGL_GREEN_SIZE, 8,
-    EGL_BLUE_SIZE, 8,
-    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
-    EGL_NONE
-};
-
 static const char options_string[] = "?fw:h:s:";
 
 static struct option long_options[] = {

--- a/config.mk
+++ b/config.mk
@@ -5,16 +5,15 @@ VERSION = 0.1
 
 # file paths
 PREFIX = /usr/local
-X11INC = /usr/X11R6/include
-X11LIB = /usr/X11R6/lib
 
 # includes and libs
-INCS = -I. -I/usr/include -I${X11INC}
-LIBS = -L/usr/lib -lc -lm -L${X11LIB} -lX11 -lEGL -lGLESv2
+INCS = -I.
+LIBS = -lc -lm -lGLESv2 $(shell pkg-config --libs glfw3)
 
 # toolchain flags
-CPPFLAGS = -DVERSION=\"${VERSION}\" -D_POSIX_C_SOURCE=200112L
-CFLAGS = -std=c99 -pedantic -Wall -O3 ${INCS} ${CPPFLAGS}
+CPPFLAGS = -DVERSION=\"${VERSION}\"
+CFLAGS = -std=c99 -pedantic -Wall -O2 ${INCS} ${CPPFLAGS} \
+	$(pkg-config --cflags glfw3)
 LDFLAGS = -s ${LIBS}
 
 # compiler and linker

--- a/esshader.c
+++ b/esshader.c
@@ -118,7 +118,15 @@ static void startup(int width, int height, bool fullscreen)
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 
-    if (!(window = glfwCreateWindow(width, height, "esshader", NULL, NULL))) {
+    GLFWmonitor *monitor = NULL;
+    if (fullscreen) {
+        monitor = glfwGetPrimaryMonitor();
+        const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+        width = mode->width;
+        height = mode->height;
+    }
+
+    if (!(window = glfwCreateWindow(width, height, "esshader", monitor, NULL))) {
         glfwTerminate();
         die("Unable to create GLFW window.\n");
     }
@@ -274,7 +282,7 @@ int main(int argc, char **argv){
             info(   "\nUsage: esshader [OPTIONS]\n"
                     "Example: esshader --width 1280 --height 720\n\n"
                     "Options:\n"
-                    " -f, --fullscreen \truns the program in (fake) fullscreen mode.\n"
+                    " -f, --fullscreen \truns the program in fullscreen mode.\n"
                     " -?, --help \t\tshows this help.\n"
                     " -w, --width [value] \tsets the window width to [value].\n"
                     " -h, --height [value] \tsets the window height to [value].\n"

--- a/esshader.c
+++ b/esshader.c
@@ -4,8 +4,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
-#include <unistd.h>
 
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
@@ -64,25 +62,6 @@ static void info(const char *format, ...) {
     va_start(args, format);
     vfprintf(stdout, format, args);
     va_end(args);
-}
-
-static double timespec_diff(const struct timespec *start, const struct timespec *stop){
-    struct timespec d;
-    if ((stop->tv_nsec - start->tv_nsec) < 0){
-        d.tv_sec = stop->tv_sec - start->tv_sec - 1;
-        d.tv_nsec = stop->tv_nsec - start->tv_nsec + 1000000000l;
-    }
-    else {
-        d.tv_sec = stop->tv_sec - start->tv_sec;
-        d.tv_nsec = stop->tv_nsec - start->tv_nsec;
-    }
-
-    return (double)d.tv_sec + (double)d.tv_nsec / 1000000000.0;
-}
-
-static void monotonic_time(struct timespec *tp){
-    if (clock_gettime(CLOCK_MONOTONIC, tp) == -1)
-        die("clock_gettime on CLOCK_MONOTIC failed.\n");
 }
 
 static GLuint compile_shader(GLenum type, GLsizei nsources, const char **sources){
@@ -252,8 +231,6 @@ static char* read_file_into_str(const char *filename) {
 int main(int argc, char **argv){
     info("ESShader -  Version: %s\n", VERSION);
 
-    struct timespec start, cur;
-    
     //Default selected_options
     bool fullscreen = false;
     int window_width = 640;
@@ -310,11 +287,10 @@ int main(int argc, char **argv){
     info("Press [ESC] or [q] to exit.\n");
     info("Run with --help flag for more information.\n\n");
     startup(window_width, window_height, fullscreen);
-    monotonic_time(&start);
+    glfwSetTime(0.0);
 
     while (!glfwWindowShouldClose(window)) {
-        render((float)timespec_diff(&start, &cur));
-        monotonic_time(&cur);
+        render((float)glfwGetTime());
         glfwSwapBuffers(window);
         glfwPollEvents();
     }

--- a/esshader.c
+++ b/esshader.c
@@ -6,10 +6,9 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+
+#define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
-#include <GLES2/gl2.h>
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
 
 #include "config.h"
 
@@ -132,6 +131,7 @@ static void startup(int width, int height, bool fullscreen)
     GLuint vtx, frag;
     const char *sources[4];
     char* log;
+    GLint success, len;
 
     if (!glfwInit())
         die("Unable to initialize GLFW.\n");
@@ -140,8 +140,10 @@ static void startup(int width, int height, bool fullscreen)
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 
-    if (!(window = glfwCreateWindow(width, height, "esshader", NULL, NULL)))
+    if (!(window = glfwCreateWindow(width, height, "esshader", NULL, NULL))) {
+        glfwTerminate();
         die("Unable to create GLFW window.\n");
+    }
 
     glfwMakeContextCurrent(window);
 
@@ -249,7 +251,6 @@ static void render(float abstime){
     glEnableVertexAttribArray(attrib_position);
     glVertexAttribPointer(attrib_position, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    eglSwapBuffers(egl_display, egl_surface);
 }
 
 //Reads a file into a string


### PR DESCRIPTION
Window and context creation, keyboard input, and timing code have all been rewritten to use the cross-platform GLFW library. As a result, esshader should now compile on other OS's, though I haven't tested this. The code is also much simpler.