### PR TITLE
Update for recent Shadertoy sources / GLSL 300, texture loading, mouse support etc.

### DIFF
--- a/config.h
+++ b/config.h
@@ -6,7 +6,7 @@
 #include <getopt.h>
 
 
-static const char options_string[] = "?fw:h:s:l0:1:2:3:x:y:";
+static const char options_string[] = "?fw:h:s:l0:1:2:3:x:y:k:";
 
 static struct option long_options[] = {
     {"width", required_argument, 0, 'w'},
@@ -21,6 +21,7 @@ static struct option long_options[] = {
     {"texture1", required_argument, 0, '1'},
     {"texture2", required_argument, 0, '2'},
     {"texture3", required_argument, 0, '3'},
+    {"keyboard", required_argument, 0, 'k'},
     {"help", no_argument, 0, '?'},
     {0, 0, 0, 0}
 };

--- a/config.h
+++ b/config.h
@@ -6,16 +6,85 @@
 #include <getopt.h>
 
 
-static const char options_string[] = "?fw:h:s:";
+static const char options_string[] = "?fw:h:s:l0:1:2:3:x:y:";
 
 static struct option long_options[] = {
     {"width", required_argument, 0, 'w'},
     {"height", required_argument, 0, 'h'},
+    {"window_x", required_argument, 0, 'x'},
+    {"window_y", required_argument, 0, 'y'},
+    {"height", required_argument, 0, 'h'},
     {"fullscreen", no_argument, 0, 'f'},
     {"source", required_argument, 0, 's'},
+    {"legacy", no_argument, 0, 'l'},
+    {"texture0", required_argument, 0, '0'},
+    {"texture1", required_argument, 0, '1'},
+    {"texture2", required_argument, 0, '2'},
+    {"texture3", required_argument, 0, '3'},
     {"help", no_argument, 0, '?'},
     {0, 0, 0, 0}
 };
+
+/*
+ * Settings for OpenGL ES 2.0 with GLSL 100 (legacy) and OpenGL ES 3.0 with GLSL 300 ES
+ */
+
+// OpenGL ES 2.0 / GLSL 100
+
+static const char common_shader_header_gles2[] =
+    "#version 100\n"
+    "precision highp float;";
+
+static const char vertex_shader_body_gles2[] =
+    "attribute vec4 iPosition;"
+    "void main(){gl_Position=iPosition;}";
+
+static const char fragment_shader_header_gles2[] =
+    "uniform vec3 iResolution;"
+    "uniform float iGlobalTime;" // legacy
+    "uniform float iTime;"
+    "uniform float iChannelTime[4];"
+    "uniform vec4 iMouse;"
+    "uniform vec4 iDate;"
+    "uniform float iSampleRate;"
+    "uniform vec3 iChannelResolution[4];"
+    "uniform sampler2D iChannel0;"
+    "uniform sampler2D iChannel1;"
+    "uniform sampler2D iChannel2;"
+    "uniform sampler2D iChannel3;\n";
+
+static const char fragment_shader_footer_gles2[] =
+    "\nvoid main(){mainImage(gl_FragColor,gl_FragCoord.xy);}";
+
+// OpenGL ES 3.0 / GLSL 300 es
+
+static const char common_shader_header_gles3[] =
+    "#version 300 es\n"
+    "precision highp float;\n";
+
+static const char vertex_shader_body_gles3[] =
+    "layout(location = 0) in vec4 iPosition;"
+    "void main() {"
+    "  gl_Position=iPosition;"
+    "}\n";
+
+static const char fragment_shader_header_gles3[] =
+    "uniform vec3 iResolution;"
+    "uniform float iGlobalTime;" // legacy
+    "uniform float iTime;"
+    "uniform float iChannelTime[4];"
+    "uniform vec4 iMouse;"
+    "uniform vec4 iDate;"
+    "uniform float iSampleRate;"
+    "uniform vec3 iChannelResolution[4];"
+    "uniform sampler2D iChannel0;"
+    "uniform sampler2D iChannel1;"
+    "uniform sampler2D iChannel2;"
+    "uniform sampler2D iChannel3;"
+    "out vec4 fragColor;\n";
+
+static const char fragment_shader_footer_gles3[] =
+    "\nvoid main(){mainImage(fragColor, gl_FragCoord.xy);}";
 
 /*
  * Standard ShaderToy Shader
@@ -23,9 +92,9 @@ static struct option long_options[] = {
 */
 
 static char *default_fragment_shader =
-    "void mainImage(out vec4 fragColor, in vec2 fragCoord)"
+    "void mainImage( out vec4 fragColor, in vec2 fragCoord )"
     "{"
-        "vec2 uv=fragCoord.xy/iResolution.xy;"
-        "fragColor = vec4(uv, 0.5+0.5*sin(iGlobalTime), 1.0);"
+    "    vec2 uv = fragCoord/iResolution.xy;"
+    "    vec3 col = 0.5 + 0.5*cos(iTime+uv.xyx+vec3(0,2,4));"
+    "    fragColor = vec4(col,1.0);"
     "}";
-

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,5 @@
 # esshader version
-VERSION = 0.1
+VERSION = 0.2
 
 # customize below to fit your system
 
@@ -8,7 +8,7 @@ PREFIX = /usr/local
 
 # includes and libs
 INCS = -I.
-LIBS = -lc -lm -lGLESv2 $(shell pkg-config --libs glfw3)
+LIBS = -lc -lm -lGLESv2 -lSOIL $(shell pkg-config --libs glfw3)
 
 # toolchain flags
 CPPFLAGS = -DVERSION=\"${VERSION}\"

--- a/esshader.c
+++ b/esshader.c
@@ -256,15 +256,14 @@ static void cursor_position_callback(GLFWwindow* window, double xpos, double ypo
 
 static void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
 {
+    printf("button %d action %d\n", button, action);
     if (button == 0) {
         mouseUpdating = action;
         mouseLPressed = action;
     } else if (button == 1) {
         mouseRPressed = action;
     }
-    if (mouseUpdating) {
-        glUniform4f(uniform_mouse, mouseX, mouseY, mouseLPressed, mouseRPressed);
-    }
+    glUniform4f(uniform_mouse, mouseX, mouseY, mouseLPressed, mouseRPressed);
 }
 
 static void startup(int width, int height, int window_x, int window_y, bool fullscreen)

--- a/esshader.c
+++ b/esshader.c
@@ -115,6 +115,7 @@ static GLuint compile_shader(GLenum type, GLsizei nsources, const char **sources
 static void resize_viewport(GLFWwindow* window, int w, int h){
     glUniform3f(uniform_res, (float)w, (float)h, 0.0f);
     glViewport(0, 0, w, h);
+    info("Setting window size to (%d,%d).\n", w, h);
     viewportSizeX = w;
     viewportSizeY = h;
 }

--- a/esshader.c
+++ b/esshader.c
@@ -123,8 +123,6 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
     if (action == GLFW_PRESS) {
         if (key == GLFW_KEY_Q || key == GLFW_KEY_ESCAPE) {
             glfwSetWindowShouldClose(window, 1);
-        } else if (key == GLFW_KEY_F5) {
-
         } else if (key == GLFW_KEY_F) {
             if (maximized) {
                 glfwRestoreWindow(window);

--- a/esshader.c
+++ b/esshader.c
@@ -153,7 +153,9 @@ static void mouse_button_callback(GLFWwindow* window, int button, int action, in
     } else if (button == 1) {
         mouseRPressed = action;
     }
-    glUniform4f(uniform_mouse, mouseX, mouseY, mouseLPressed, mouseRPressed);
+    if (mouseUpdating) {
+        glUniform4f(uniform_mouse, mouseX, mouseY, mouseLPressed, mouseRPressed);
+    }
 }
 
 static void startup(int width, int height, int window_x, int window_y, bool fullscreen)


### PR DESCRIPTION
I submit for review an update to this extremely handy application targeted towards general support of more recent Shadertoy demos (e.g. https://www.shadertoy.com/view/ltffzl); also added textures and some more stuff while trying to preserve the minimalist spirit. I also dared increase VERSION to 0.2 at the same time.

- Added support for recent shaders; default to GLES 3.0 / GLSL 300 es scaffold,
    with -l switch for legacy sources
- Added support for loading textures to iChannelX (NOTE: new build dep on libSOIL!)
- Added Shadertoy-compatible mouse event relaying (tested 2019-09)
- Added iTime uniform for newer sources (just keeping iGlobalTime as well)
- Added maximize toggle for windowed mode (hotkey F)
- Added support for startup window position arguments -x <int> -y <int>
- Updated the default shader code from current ST new project page

!!! NOTE: Adds new dependency on libSOIL for simple image loading to OpenGL textures (unchanged but trusted for 10 years, packaged in many distros): https://www.lonesock.net/soil.html

P.S. esshader is an excellent little tool; sincere thanks! (Now I can comfortably use gvim to tinker with ST code.)
